### PR TITLE
Add an entry point mode

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,5 @@
+{
+  "node": true,
+  "unused": true,
+  "undef": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+
+* Allow specifying an entry point, in addition to the default mode of creating one containing an import for all css files automatically.
+
 ## 0.0.3
 
 * __BUG__: Fix relativity of the sourceMappingURL in the end comment.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ First, you need to have gobble installed - see the [gobble readme](https://githu
 
 ## Usage
 
+You can use this transform in two modes.
+
+1. The first finds all of the css files available in the gobble nodes that it is handed and concatenates them. This is fine if you have a bunch of unrelated styesheets that you just want globbed together.
+2. If some of the stylesheets are interrelated (via `@import`) or you need to control the order in which they are concatenated, you can create an entry file that references all of the files you need and specify it as an entry point.
+
+If no `entry` option is specified, then the first mode will be used. 
+
 ### Options
 
-* sourcemap - boolean - defaults to true - whether or not to generate sourcemaps
-* dest - string - defaults to `'bundle.css'` - the name of the file to output
-* debug - boolean - `console.log` each url that is adjusted
+* `sourcemap` - boolean - defaults to true - whether or not to generate sourcemaps - alias `sourceMap` to match other plugin convention
+* `dest` - string - defaults to `'bundle.css'` - the name of the file to output
+* `debug` - boolean - `console.log` each url that is adjusted
+* `entry` - string - name of the file from which to start - if not specified an entry `@import`ing all available css files will be created for you
 
 ```js
 gobble('path-with-css').transform('concat-css', { dest: 'assets/bundle.css' });

--- a/index.js
+++ b/index.js
@@ -5,59 +5,109 @@ var path = require('path');
 
 var absolute = /^\s*\w+:\/\//;
 var css = /\.css$/;
+var cssMap = /\.css\.map$/;
+
+var Promise;
 
 function concatCss(indir, outdir, opts) {
-  var sander = this.sander,
-      dest = opts.dest || 'bundle.css',
-      map = dest + '.map',
-      sourcemap = opts.sourcemap !== false,
-      ctx = this,
-      root = path.dirname(dest)
-        .split('/')
-        .filter(function(p) { return p !== '.'; })
-        .map(function() { return '..'; })
-        .join('/');
+  Promise = this.sander.Promise;
+  var dest = opts.dest || 'bundle.css';
+  var details = {
+    indir: indir,
+    outdir: outdir,
+    opts: opts,
+    dest: dest,
+    sander: this.sander,
+    map: dest + '.map',
+    entry: opts.entry,
+    sourcemap: opts.sourceMap === false || opts.sourcemap !== false,
+    ctx: this,
+    root: path.dirname(dest)
+      .split('/')
+      .filter(function(p) { return p !== '.'; })
+      .map(function() { return '..'; })
+      .join('/')
+  };
 
-  return sander.lsr(indir).then(function(files) {
-    var others = files.filter(function(f) { return !css.test(f); });
-    files = files.filter(function(f) { return css.test(f); });
-    ctx.log('finding css files...');
-    var step1 = sander.Promise.all(files.map(function(f) {
-      return sander.readFile(indir, f).then(function(content) {
-        var fn = function(u) {
-          var res;
-          if (absolute.test(u)) res = u;
-          else res = path.join(root, path.dirname(f), u);
-          if (opts.debug) console.log('replacing', u, 'with', res);
-          return res;
-        };
-        return sander.writeFile(outdir, f, rework(content.toString()).use(url(fn)).toString());
+  if (details.entry) {
+    return concatFrom(details);
+  } else {
+    return concatAll(details);
+  }
+}
+
+function concatAll(opts) {
+  opts.root = opts.outdir;
+  return findFiles(opts).then(function() {
+    var step1 = opts.sander.Promise.all(opts.files.map(function(f) {
+      return opts.sander.readFile(opts.indir, f).then(function(content) {
+        opts.str = content.toString();
+        return opts.sander.writeFile(opts.outdir, f, fixUrls(f, opts));
       });
     }));
 
     return step1.then(function() {
-      ctx.log('bundling css...');
-      var str = files
-        .map(function(f) { return '@import "./' + outdir.replace(process.cwd(), '') + '/' + f + '";'; })
+      var str = opts.files
+        .map(function(f) { return '@import "' + f + '";'; })
         .join('\n');
-      var output = rework(str).use(imprt()).toString(sourcemap ? { sourcemap: true, sourcemapAsObject: true } : {});
-      output.code += '\n' + '/*# sourceMappingURL=' + path.basename(map) + '\n */';
 
-      // delete leftover files from step1
-      ctx.log('cleaning up...');
-      return Promise.all(files.map(function(f) { return sander.unlink(outdir, f); })).then(function() {
-        // write out the bundle
-        ctx.log('saving bundle...');
-        return sander.writeFile(outdir, dest, output.code)
-          .then(function() {
-            ctx.log('saving source map...');
-            return sander.writeFile(outdir, map, JSON.stringify(output.map)).then(function() {
-              ctx.log('copying other files...');
-              return Promise.all(others.map(function(f) { sander.link(indir, f).to(outdir, f); }));
-            });
-          });
-      });
+      opts.str = str;
+      return runConcat(opts);
     });
+  });
+}
+
+function fixUrls(file, opts) {
+  var fn = function(u) {
+    var res;
+    if (absolute.test(u)) res = u;
+    else res = path.join(opts.root, path.dirname(file), u);
+    if (opts.debug) console.log('replacing', u, 'with', res);
+    return res;
+  };
+  opts.str = rework(opts.str).use(url(fn)).toString();
+  return opts.str;
+}
+
+function concatFrom(opts) {
+  opts.root = path.join(opts.indir, path.dirname(opts.entry));
+  return findFiles(opts).then(function() {
+    return opts.sander.readFile(opts.indir, opts.entry).then(function(content) {
+      opts.str = content.toString();
+      fixUrls(opts.entry, opts);
+      return runConcat(opts);
+    });
+  });
+}
+
+function runConcat(opts) {
+  opts.ctx.log('bundling css...');
+  var output = rework(opts.str).use(imprt({ path: opts.root })).toString(opts.sourcemap ? { sourcemap: true, sourcemapAsObject: true } : {});
+  output.code += '\n' + '//# sourceMappingURL=' + path.basename(opts.map);
+
+  // delete leftover files from step1
+  opts.ctx.log('cleaning up...');
+  return Promise.all(opts.files.map(function(f) { return opts.sander.unlink(opts.outdir, f).then(noop, noop); })).then(function() {
+    // write out the bundle
+    opts.ctx.log('saving bundle...');
+    return opts.sander.writeFile(opts.outdir, opts.dest, output.code)
+      .then(function() {
+        opts.ctx.log('saving source map...');
+        return opts.sander.writeFile(opts.outdir, opts.map, JSON.stringify(output.map)).then(function() {
+          opts.ctx.log('copying other files...');
+          return Promise.all(opts.others.map(function(f) { return opts.sander.link(opts.indir, f).to(opts.outdir, f); }));
+        });
+      });
+  });
+}
+
+function noop() {}
+
+function findFiles(opts) {
+  return opts.sander.lsr(opts.indir).then(function(files) {
+    opts.others = files.filter(function(f) { return !css.test(f) && !cssMap.test(f); });
+    opts.files = files.filter(function(f) { return css.test(f); });
+    opts.ctx.log('finding css files...');
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gobble-concat-css",
   "license": "MIT",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "A gobble plugin to concatenate css files",
   "homepage": "https://github.com/evs-chris/gobble-concat-css",
   "author": { "name": "Chris Reeves" },


### PR DESCRIPTION
This allows you to specify an entry file, as opposed to creating one containing all of the available css files automatically.

`gobble('my/css', { entry: 'index.css', sourceMap: true })`

@brakmic If you get a change, could you clone this branch into your node_modules and give it a try? If it works for you, I'll publish as 0.1.0.
